### PR TITLE
Add ports for gps and position-reset to the UWPoseEstimator-Task

### DIFF
--- a/pose_estimation.orogen
+++ b/pose_estimation.orogen
@@ -75,6 +75,18 @@ task_context "UWPoseEstimator" do
     input_port( "xy_position_samples", "/base/samples/RigidBodyState" ).
 	needs_reliable_connection.
 	doc "position samples from a localization module, containing the xy position in world coordinates."
+	
+    input_port( "gps_position_samples", "/base/samples/RigidBodyState" ).
+	needs_reliable_connection.
+	doc "position samples from a gps-sensor, containing position in gps-coordinates"
+	
+    input_port( "reset_position_samples", "/base/samples/RigidBodyState" ).
+	needs_reliable_connection.
+	doc "External position for reseting the filter to a known position"
+	
+   
+    operation( "reset_to_origin").
+	doc "Reset the position to the origin"
 
 
     #******************************
@@ -85,6 +97,7 @@ task_context "UWPoseEstimator" do
         transformation("pressure_sensor", "body")
         transformation("dvl", "body")
         transformation("lbl", "body")
+        transformation("gps", "body")
         
 	align_port("orientation_samples", 0.01)
 	align_port("depth_samples", 0.01)
@@ -92,6 +105,8 @@ task_context "UWPoseEstimator" do
 	align_port("model_velocity_samples", 0.01)
 	align_port("lbl_position_samples", 0.01)
 	align_port("xy_position_samples", 0.01)
+	align_port("gps_position_samples", 0.01)
+	align_port("reset_position_samples", 0.01)
 	max_latency(0.1)
     end
 

--- a/pose_estimation.orogen
+++ b/pose_estimation.orogen
@@ -80,6 +80,10 @@ task_context "UWPoseEstimator" do
 	needs_reliable_connection.
 	doc "position samples from a gps-sensor, containing position in gps-coordinates"
 
+    input_port( "xyz_position_samples", "/base/samples/RigidBodyState" ).
+	needs_reliable_connection.
+	doc "position samples from a localization module, containing the xyz position in world coordinates."
+	
 
     #******************************
     #** Aggregator Parameters ***** 
@@ -98,6 +102,7 @@ task_context "UWPoseEstimator" do
 	align_port("lbl_position_samples", 0.01)
 	align_port("xy_position_samples", 0.01)
 	align_port("gps_position_samples", 0.01)
+	align_port("xyz_position_samples", 0.01)
 	max_latency(0.1)
     end
 

--- a/pose_estimation.orogen
+++ b/pose_estimation.orogen
@@ -79,14 +79,6 @@ task_context "UWPoseEstimator" do
     input_port( "gps_position_samples", "/base/samples/RigidBodyState" ).
 	needs_reliable_connection.
 	doc "position samples from a gps-sensor, containing position in gps-coordinates"
-	
-    input_port( "reset_position_samples", "/base/samples/RigidBodyState" ).
-	needs_reliable_connection.
-	doc "External position for reseting the filter to a known position"
-	
-   
-    operation( "reset_to_origin").
-	doc "Reset the position to the origin"
 
 
     #******************************
@@ -106,7 +98,6 @@ task_context "UWPoseEstimator" do
 	align_port("lbl_position_samples", 0.01)
 	align_port("xy_position_samples", 0.01)
 	align_port("gps_position_samples", 0.01)
-	align_port("reset_position_samples", 0.01)
 	max_latency(0.1)
     end
 

--- a/tasks/UWPoseEstimator.cpp
+++ b/tasks/UWPoseEstimator.cpp
@@ -83,39 +83,6 @@ void UWPoseEstimator::gps_position_samplesTransformerCallback(const base::Time &
   
 }
 
-
-void UWPoseEstimator::reset_position_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &reset_position_samples_sample)
-{
-  base::samples::RigidBodyState rbs;
-  rbs.position = reset_position_samples_sample.position;
-  rbs.cov_position = base::Matrix3d::Identity() * 1e-9; //Use very small variance 
-  
-  MeasurementConfig config;
-  config.measurement_mask[BodyStateMemberX] = 1;
-  config.measurement_mask[BodyStateMemberY] = 1;
-  
-  //If we have a valid orientation -> Use yaw
-  if(reset_position_samples_sample.hasValidOrientation())
-  {
-    rbs.orientation = reset_position_samples_sample.orientation;
-    rbs.cov_position = base::Matrix3d::Identity() * 1e-9;
-    
-    config.measurement_mask[BodyStateMemberYaw] = 1;    
-  }
-  
-  handleMeasurement(ts, rbs, config);
-  
-}
-
-
-void UWPoseEstimator::reset_to_origin()
-{
-  base::samples::RigidBodyState rbs;
-  rbs.position = base::Vector3d::Zero();
-  
-  reset_position_samplesTransformerCallback(base::Time::now(), rbs);
-}
-
 /// The following lines are template definitions for the various state machine
 // hooks defined by Orocos::RTT. See UWPoseEstimator.hpp for more detailed
 // documentation about them.

--- a/tasks/UWPoseEstimator.cpp
+++ b/tasks/UWPoseEstimator.cpp
@@ -72,6 +72,50 @@ void UWPoseEstimator::model_velocity_samplesTransformerCallback(const base::Time
     handleMeasurement(ts, model_velocity_samples_sample, config);
 }
 
+
+void UWPoseEstimator::gps_position_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &gps_position_samples_sample)
+{
+  MeasurementConfig config;
+  config.measurement_mask[BodyStateMemberX] = 1;
+  config.measurement_mask[BodyStateMemberY] = 1;
+  
+  handleMeasurement(ts, gps_position_samples_sample, config,  _gps2body);
+  
+}
+
+
+void UWPoseEstimator::reset_position_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &reset_position_samples_sample)
+{
+  base::samples::RigidBodyState rbs;
+  rbs.position = reset_position_samples_sample.position;
+  rbs.cov_position = base::Matrix3d::Identity() * 1e-9; //Use very small variance 
+  
+  MeasurementConfig config;
+  config.measurement_mask[BodyStateMemberX] = 1;
+  config.measurement_mask[BodyStateMemberY] = 1;
+  
+  //If we have a valid orientation -> Use yaw
+  if(reset_position_samples_sample.hasValidOrientation())
+  {
+    rbs.orientation = reset_position_samples_sample.orientation;
+    rbs.cov_position = base::Matrix3d::Identity() * 1e-9;
+    
+    config.measurement_mask[BodyStateMemberYaw] = 1;    
+  }
+  
+  handleMeasurement(ts, rbs, config);
+  
+}
+
+
+void UWPoseEstimator::reset_to_origin()
+{
+  base::samples::RigidBodyState rbs;
+  rbs.position = base::Vector3d::Zero();
+  
+  reset_position_samplesTransformerCallback(base::Time::now(), rbs);
+}
+
 /// The following lines are template definitions for the various state machine
 // hooks defined by Orocos::RTT. See UWPoseEstimator.hpp for more detailed
 // documentation about them.

--- a/tasks/UWPoseEstimator.cpp
+++ b/tasks/UWPoseEstimator.cpp
@@ -83,6 +83,17 @@ void UWPoseEstimator::gps_position_samplesTransformerCallback(const base::Time &
   
 }
 
+
+void UWPoseEstimator::xyz_position_samplesTransformerCallback( const base::Time &ts, const ::base::samples::RigidBodyState &xyz_position_samples_sample)
+{
+  MeasurementConfig config;
+  config.measurement_mask[BodyStateMemberX] = 1;
+  config.measurement_mask[BodyStateMemberY] = 1;
+  config.measurement_mask[BodyStateMemberZ] = 1;
+  
+  handleMeasurement(ts, xyz_position_samples_sample, config);
+}
+  
 /// The following lines are template definitions for the various state machine
 // hooks defined by Orocos::RTT. See UWPoseEstimator.hpp for more detailed
 // documentation about them.

--- a/tasks/UWPoseEstimator.hpp
+++ b/tasks/UWPoseEstimator.hpp
@@ -40,6 +40,8 @@ namespace pose_estimation {
 	
 	virtual void gps_position_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &gps_position_samples_sample);
 
+	virtual void xyz_position_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &xyz_position_samples_sample);
+	
     public:
         /** TaskContext constructor for UWPoseEstimator
          * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.

--- a/tasks/UWPoseEstimator.hpp
+++ b/tasks/UWPoseEstimator.hpp
@@ -39,10 +39,6 @@ namespace pose_estimation {
 	virtual void model_velocity_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &model_velocity_samples_sample);
 	
 	virtual void gps_position_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &gps_position_samples_sample);
-	
-	virtual void reset_position_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &reset_position_samples_sample);
-	
-	void reset_to_origin();
 
     public:
         /** TaskContext constructor for UWPoseEstimator

--- a/tasks/UWPoseEstimator.hpp
+++ b/tasks/UWPoseEstimator.hpp
@@ -37,6 +37,12 @@ namespace pose_estimation {
         virtual void dvl_velocity_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &dvl_velocity_samples_sample);
 	
 	virtual void model_velocity_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &model_velocity_samples_sample);
+	
+	virtual void gps_position_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &gps_position_samples_sample);
+	
+	virtual void reset_position_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &reset_position_samples_sample);
+	
+	void reset_to_origin();
 
     public:
         /** TaskContext constructor for UWPoseEstimator


### PR DESCRIPTION
I added two additional ports for gps-input and reseting the position, based on an external reference, to the UWPoseEstimatior-Task. The position-reset can be done by using the input-port or a defined operation
