### PR TITLE
remove the velocity update in case there is a pose update from the same source

### DIFF
--- a/tasks/HighDelayPoseEstimator.cpp
+++ b/tasks/HighDelayPoseEstimator.cpp
@@ -23,18 +23,12 @@ void HighDelayPoseEstimator::pose_samples_slowTransformerCallback(const base::Ti
     DelayedMeasurement measurement;
     measurement.measurement = pose_samples_slow_sample;
     measurement.ts = ts;
-    measurement.config.measurement_mask[BodyStateMemberX] = 0;
-    measurement.config.measurement_mask[BodyStateMemberY] = 0;
     measurement.config.measurement_mask[BodyStateMemberZ] = 1;
     measurement.config.measurement_mask[BodyStateMemberVx] = 1;
     measurement.config.measurement_mask[BodyStateMemberVy] = 1;
-    measurement.config.measurement_mask[BodyStateMemberVz] = 1;
     measurement.config.measurement_mask[BodyStateMemberRoll] = 1;
     measurement.config.measurement_mask[BodyStateMemberPitch] = 1;
     measurement.config.measurement_mask[BodyStateMemberYaw] = 1;
-    measurement.config.measurement_mask[BodyStateMemberVroll] = 1;
-    measurement.config.measurement_mask[BodyStateMemberVpitch] = 1;
-    measurement.config.measurement_mask[BodyStateMemberVyaw] = 1;
     // transform velocity to source frame, since the input is expected to be this way
     measurement.measurement.velocity = pose_samples_slow_sample.orientation.inverse() * pose_samples_slow_sample.velocity;
     delayed_measurements.push_back(measurement);

--- a/tasks/UWPoseEstimator.cpp
+++ b/tasks/UWPoseEstimator.cpp
@@ -22,7 +22,6 @@ void UWPoseEstimator::depth_samplesTransformerCallback(const base::Time &ts, con
 {
     MeasurementConfig config;
     config.measurement_mask[BodyStateMemberZ] = 1;
-    config.measurement_mask[BodyStateMemberVz] = 1;
     handleMeasurement(ts, depth_samples_sample, config, _pressure_sensor2body);
 }
 
@@ -32,9 +31,6 @@ void UWPoseEstimator::orientation_samplesTransformerCallback(const base::Time &t
     config.measurement_mask[BodyStateMemberRoll] = 1;
     config.measurement_mask[BodyStateMemberPitch] = 1;
     config.measurement_mask[BodyStateMemberYaw] = 1;
-    config.measurement_mask[BodyStateMemberVroll] = 1;
-    config.measurement_mask[BodyStateMemberVpitch] = 1;
-    config.measurement_mask[BodyStateMemberVyaw] = 1;
     handleMeasurement(ts, orientation_samples_sample, config, _imu2body);
 }
 


### PR DESCRIPTION
The reason is that the RBS does not have a full covariance matrix to model the coupling between both measurements. Therefore the filter might become overconfident over time.
