### PR TITLE
handle acceleration samples in the UWPoseEstimator task

### DIFF
--- a/pose_estimation.orogen
+++ b/pose_estimation.orogen
@@ -55,6 +55,10 @@ task_context "UWPoseEstimator" do
     #******************************
     #******* Input Ports **********
     #******************************
+    input_port( "acceleration_samples", "/base/samples/RigidBodyAcceleration" ).
+        needs_reliable_connection.
+        doc "acceleration samples with uncertainty from an IMU, in case this port is connected the measurement uncertainty is used instead of the process noise."
+
     input_port( "orientation_samples", "/base/samples/RigidBodyState" ).
 	needs_reliable_connection.
 	doc "orientation samples from an IMU and or a FOG, containing the orientation and the angular velocity."
@@ -98,6 +102,7 @@ task_context "UWPoseEstimator" do
         transformation("lbl", "body")
         transformation("gps", "body")
         
+        align_port("acceleration_samples", 0.01)
 	align_port("orientation_samples", 0.01)
 	align_port("depth_samples", 0.01)
 	align_port("dvl_velocity_samples", 0.01)

--- a/pose_estimationTypes.hpp
+++ b/pose_estimationTypes.hpp
@@ -14,7 +14,7 @@ struct MeasurementConfig
 {
     base::VectorXd measurement_mask;
 
-    MeasurementConfig() : measurement_mask(BODY_STATE_SIZE, 1) {measurement_mask.setZero();}
+    MeasurementConfig() : measurement_mask(MEASUREMENT_SIZE, 1) {measurement_mask.setZero();}
 };
 
 struct ProcessNoise

--- a/tasks/BaseTask.cpp
+++ b/tasks/BaseTask.cpp
@@ -80,6 +80,13 @@ void BaseTask::handleMeasurement(const base::Time& ts, const base::samples::Rigi
 	RTT::log(RTT::Error) << "Failed to add measurement from " << measurement.sourceFrame << "." << RTT::endlog();
 }
 
+void BaseTask::handleMeasurement(const base::Time& ts, const base::samples::RigidBodyState& measurement, const base::samples::RigidBodyAcceleration& measurement_acc, const MeasurementConfig& config)
+{
+    // enqueue new measurement
+    if(!pose_estimator->enqueueMeasurement(ts, measurement, measurement_acc, config.measurement_mask.cast<unsigned>()))
+        RTT::log(RTT::Error) << "Failed to add measurement from " << measurement.sourceFrame << "." << RTT::endlog();
+}
+
 void BaseTask::updateState()
 {
     // integrate measurements

--- a/tasks/BaseTask.cpp
+++ b/tasks/BaseTask.cpp
@@ -38,9 +38,9 @@ void BaseTask::handleMeasurement(const base::Time& ts, const base::samples::Rigi
         if(config.measurement_mask[i] == 0)
             transformed_rbs.position[i] = 0.0;
     }
-    for(unsigned i = 6; i < 9; i++)
+    for(unsigned i = 0; i < 3; i++)
     {
-        if(config.measurement_mask[i] == 0)
+        if(config.measurement_mask[BodyStateMemberVx+i] == 0)
             transformed_rbs.velocity[i] = 0.0;
     }
 

--- a/tasks/BaseTask.hpp
+++ b/tasks/BaseTask.hpp
@@ -44,6 +44,7 @@ namespace pose_estimation {
 	
 	void handleMeasurement(const base::Time &ts, const base::samples::RigidBodyState &measurement, const MeasurementConfig &config, const transformer::Transformation& sensor2body_transformer);
 	void handleMeasurement(const base::Time &ts, const base::samples::RigidBodyState &measurement, const MeasurementConfig &config);
+        void handleMeasurement(const base::Time &ts, const base::samples::RigidBodyState &measurement, const base::samples::RigidBodyAcceleration &measurement_acc, const MeasurementConfig &config);
 
         bool setupFilter();
 	

--- a/tasks/UWPoseEstimator.cpp
+++ b/tasks/UWPoseEstimator.cpp
@@ -18,6 +18,16 @@ UWPoseEstimator::~UWPoseEstimator()
 {
 }
 
+void UWPoseEstimator::acceleration_samplesTransformerCallback(const base::Time& ts, const base::samples::RigidBodyAcceleration& acceleration_samples_sample)
+{
+    MeasurementConfig config;
+    config.measurement_mask[BodyStateMemberAx] = 1;
+    config.measurement_mask[BodyStateMemberAy] = 1;
+    config.measurement_mask[BodyStateMemberAz] = 1;
+    base::samples::RigidBodyState aux;
+    handleMeasurement(ts, aux, acceleration_samples_sample, config);
+}
+
 void UWPoseEstimator::depth_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &depth_samples_sample)
 {
     MeasurementConfig config;

--- a/tasks/UWPoseEstimator.hpp
+++ b/tasks/UWPoseEstimator.hpp
@@ -4,6 +4,8 @@
 #define POSE_ESTIMATION_UWPOSEESTIMATOR_TASK_HPP
 
 #include "pose_estimation/UWPoseEstimatorBase.hpp"
+#include "base/samples/RigidBodyState.hpp"
+#include "base/samples/RigidBodyAcceleration.hpp"
 
 namespace pose_estimation {
 
@@ -25,6 +27,8 @@ namespace pose_estimation {
     {
 	friend class UWPoseEstimatorBase;
     protected:
+
+        virtual void acceleration_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyAcceleration &acceleration_samples_sample);
 
         virtual void depth_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &depth_samples_sample);
 


### PR DESCRIPTION
This adds a new input port for acceleration measurements to the UWPoseEstimator task.
It depends on rock-slam/slam-pose_estimation#3
