### PR TITLE
allow overriding the max latency of the filter

### DIFF
--- a/pose_estimation.orogen
+++ b/pose_estimation.orogen
@@ -116,6 +116,8 @@ task_context "UWPoseEstimator" do
 	max_latency(0.1)
     end
 
+    find_property('transformer_max_latency').dynamic
+
     periodic 0.01
 end
 

--- a/tasks/UWPoseEstimator.cpp
+++ b/tasks/UWPoseEstimator.cpp
@@ -260,6 +260,19 @@ void UWPoseEstimator::xyz_position_samplesTransformerCallback( const base::Time 
     else
         RTT::log(RTT::Error) << "XYZ position measurement contains NaN's, it will be skipped!" << RTT::endlog();
 }
+
+bool UWPoseEstimator::setTransformer_max_latency(double value)
+{
+    if (pose_estimation::UWPoseEstimatorBase::setTransformer_max_latency(value))
+    {
+        _transformer.setTimeout( base::Time::fromSeconds(value) );
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
   
 /// The following lines are template definitions for the various state machine
 // hooks defined by Orocos::RTT. See UWPoseEstimator.hpp for more detailed

--- a/tasks/UWPoseEstimator.hpp
+++ b/tasks/UWPoseEstimator.hpp
@@ -46,6 +46,8 @@ namespace pose_estimation {
 
 	virtual void xyz_position_samplesTransformerCallback(const base::Time &ts, const ::base::samples::RigidBodyState &xyz_position_samples_sample);
 	
+        virtual bool setTransformer_max_latency(double value);
+
     public:
         /** TaskContext constructor for UWPoseEstimator
          * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.


### PR DESCRIPTION
This can be temporarily used at runtime to synchronize a low-latency
filter (i.e. dead reckoning) with a high-latency one (i.e. global
positioning) by feeding the latter in the xy_samples port of the
former. Obviously, it must be done in a (control) state where the
fast latency filter is unused.