### PR TITLE
fix: use full path for pose_estimationTypes.hpp inclusion

### DIFF
--- a/tasks/RBSFilter.hpp
+++ b/tasks/RBSFilter.hpp
@@ -8,7 +8,6 @@
 #include <boost/shared_ptr.hpp>
 #include <pose_estimation/pose_with_velocity/PoseUKF.hpp>
 #include <transformer/Transformer.hpp>
-#include <pose_estimationTypes.hpp>
 #include <pose_estimation/StreamAlignmentVerifier.hpp>
 #include <base/samples/RigidBodyAcceleration.hpp>
 


### PR DESCRIPTION
I am trying to subclass some of the filters that use the RBSFilter, but not using the full path to include pose_estimationTypes.hpp is causing compilation errors.